### PR TITLE
Add integration test to CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Check git-tag-annotation-action output
       shell: bash
       run: |
-        if ! [[ "${{ steps.action_test.outputs.git-tag-annotation }}" ]]; then
-            exit 1
+        if ! [[ "${{ steps.action_test.outputs.git-tag-annotations }}" ]]; then
+          exit 1
         fi
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,8 +5,23 @@ on:
 - pull_request
 
 jobs:
-  build-and-test:
-    name: Build & Test
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Initialize repository
+      run: npm ci
+    - name: Build lib/index.js
+      run: npm run build
+  test-unit:
+    name: Unit tests
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,7 +35,42 @@ jobs:
         node-version: 12.x
     - name: Initialize repository
       run: npm ci
-    - name: Build lib/index.js
-      run: npm run build
     - name: Run tests
       run: npm run test
+  test-integration:
+    name: Integration tests
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Initialize repository
+      run: npm ci
+    - name: Build lib/index.js
+      run: npm run build
+    - name: Move git-tag-annotation-action
+      shell: bash
+      run: |
+        mkdir ./../action
+        mv ./lib ./action.yml ./../action
+    - name: Run git-tag-annotation-action
+      id: action_test
+      uses: ./../action
+      with:
+        tag: v1.0.0
+    - name: Echo git-tag-annotation-action output
+      run: echo "${{ steps.action_test.outputs.git-tag-annotation }}"
+    - name: Check git-tag-annotation-action output
+      shell: bash
+      run: |
+        if ! [[ "${{ steps.action_test.outputs.git-tag-annotation }}" ]]; then
+            exit 1
+        fi
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Check git-tag-annotation-action output
       shell: bash
       run: |
-        if ! [[ "${{ steps.action_test.outputs.git-tag-annotations }}" ]]; then
+        if ! [[ "${{ steps.action_test.outputs.git-tag-annotation }}" ]]; then
           exit 1
         fi
 


### PR DESCRIPTION
This adds a new job to the CI that runs this Action as [a local action](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-action-in-the-same-repository-as-the-workflow) to verify that it works (more or less) as expected.

Additionally, it splits up the ["Build & Test"](https://github.com/ericcornelissen/git-tag-annotation-action/blob/ec7567cee2fd693a6c2a95eb7d892cc5505fa457/.github/workflows/verify.yml#L8-L26) job into a "Build" job and "Unit Tests" job, where the former no longer works on a matrix of OSs, but just `ubuntu-latest`.