### PR TITLE
Don't filter by paths `on: push` in code analysis workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,11 +1,6 @@
 name: Code Analysis
 on:
   push:
-    paths:
-      - ".github/workflows/code-analysis.yml"
-      - ".github/codeql.yml"
-      - "src/**.js"
-      - "index.js"
   pull_request:
     paths:
       - ".github/workflows/code-analysis.yml"


### PR DESCRIPTION
Following this warning from CodeQL outputted by [`github/codeql-action/init@v1.0.24`](https://github.com/ericcornelissen/git-tag-annotation-action/blob/6d2c88c1f1866ef3da96ab537fa0f54f48617b6a/.github/workflows/code-analysis.yml#L29-L33).

![image](https://user-images.githubusercontent.com/3742559/151065415-fd3b5cec-3d79-4b0b-a417-14def3b4e76a.png)
