### PR TITLE
Improve git hooks

### DIFF
--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+MERGE_HEAD="$(git rev-parse --git-dir)/MERGE_HEAD"
+
 get_stash_count () {
   local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
   if [ "$count" = "" ]

--- a/script/hooks/common.sh
+++ b/script/hooks/common.sh
@@ -4,8 +4,7 @@ MERGE_HEAD="$(git rev-parse --git-dir)/MERGE_HEAD"
 
 get_stash_count () {
   local count=$(git rev-list --walk-reflogs --count refs/stash 2> /dev/null)
-  if [ "$count" = "" ]
-  then
+  if [ "$count" = "" ]; then
     echo "0"
   else
     echo $count

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,8 +4,7 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-if [ ! -f "$MERGE_HEAD" ]
-then
+if [ ! -f "$MERGE_HEAD" ]; then
   git stash push --include-untracked --keep-index --quiet
 fi
 
@@ -15,7 +14,6 @@ git update-index --again
 
 # Post
 STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
-then
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -4,7 +4,10 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-git stash push --include-untracked --keep-index --quiet
+if [ ! -f "$MERGE_HEAD" ]
+then
+  git stash push --include-untracked --keep-index --quiet
+fi
 
 # Checks
 npm run format

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -5,7 +5,7 @@
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
 if [ ! -f "$MERGE_HEAD" ]; then
-  git stash push --include-untracked --keep-index --quiet
+  git stash push --include-untracked --quiet
 fi
 
 # Checks

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,8 +4,7 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-if [ ! -f "$MERGE_HEAD" ]
-then
+if [ ! -f "$MERGE_HEAD" ]; then
   git stash push --include-untracked --keep-index --quiet
 fi
 
@@ -15,7 +14,6 @@ npm run test
 
 # Post
 STASH_COUNT_AFTER=$(get_stash_count)
-if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]
-then
+if [ "$STASH_COUNT_BEFORE" -lt "$STASH_COUNT_AFTER" ]; then
   git stash pop --quiet
 fi

--- a/script/hooks/pre-push
+++ b/script/hooks/pre-push
@@ -4,7 +4,10 @@
 
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
-git stash push --include-untracked --keep-index --quiet
+if [ ! -f "$MERGE_HEAD" ]
+then
+  git stash push --include-untracked --keep-index --quiet
+fi
 
 # Checks
 npm run lint


### PR DESCRIPTION
Improve the git hooks that were added in #76 (and fixed in #83):

- Update the formatting of `if` statements.
- Don't create stash during merging (which would mess up the merge commit).
- **Do** stash staged changes in the pre-push hook (so the checks run on what's being pushed).