### PR TITLE
Prevent committing changes in lib/

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -2,10 +2,14 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-# Prevent committing changes to the machine generated contents of lib/
-git restore --staged lib/
-
 # Pre
+LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc -l)
+if [ "$LIB_STAGED_COUNT" -ne "0" ]; then
+  echo "[INFO] All changes to the lib/ directory have been unstaged"
+  echo "[INFO] Changes in the lib/ directory should not be committed"
+  git restore --staged lib/
+fi
+
 STASH_COUNT_BEFORE=$(get_stash_count)
 if [ ! -f "$MERGE_HEAD" ]; then
   git stash push --include-untracked --keep-index --quiet

--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -2,6 +2,9 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
+# Prevent committing changes to the machine generated contents of lib/
+git restore --staged lib/
+
 # Pre
 STASH_COUNT_BEFORE=$(get_stash_count)
 if [ ! -f "$MERGE_HEAD" ]; then


### PR DESCRIPTION
These should only be committed by the [`update-index.yml` workflow](https://github.com/ericcornelissen/git-tag-annotation-action/blob/623534f482d63b69e3fd78f2dc5d5aa08fdbed4d/.github/workflows/update-index.yml) (possibly a different workflow if #98 gets merged)