### PR TITLE
Add CodeQL pack for GitHub Actions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -35,5 +35,7 @@ jobs:
         with:
           config-file: ./.github/codeql.yml
           languages: javascript
+          packs: >-
+            aeisenberg/codeql-actions-queries@1.0.1
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2.1.8

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -28,6 +28,7 @@ jobs:
             ghcr.io:443
             github.com:443
             pkg-containers.githubusercontent.com:443
+            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@v3.0.1
       - name: Initialize CodeQL


### PR DESCRIPTION
Based on: https://github.blog/2022-04-19-sharing-security-expertise-through-codeql-packs-part-i/