### PR TITLE
Use `node:` imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
-const childProcess = require("child_process");
-const os = require("os");
-const { env } = require("process");
+const childProcess = require("node:child_process");
+const os = require("node:os");
+const { env } = require("node:process");
 const shescape = require("shescape");
 
 const main = require("./src/main.js");

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,5 +9,6 @@ module.exports = {
     file: "lib/index.js",
     format: "cjs",
   },
+  external: ["node:child_process", "node:os", "node:process"],
   plugins: [commonjs(), nodeResolve(), terser()],
 };


### PR DESCRIPTION
Update the source code to use `node:` imports (see [the docs](https://nodejs.org/api/esm.html#esm_node_imports) for more details) so that these are valid absolute URLs and cannot accidentally be overridden by a third-party dependency.

#### Notes

- I do not plan to backport this change to v1 because I believe those might not work because the `node:` protocol isn't present in most (all?) Node v12 versions (see #111 for context). If anyone thinks it would be possible to use `node:` with the Node v12 runtime, feel free to submit a Pull Request to refactor v1 to use it.