### PR TITLE
Updates for end of general support of v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Update deprecation warning for end-of-life (EOL) of v1 of this Action.
 - Update dependencies (_actions/core_).
 
 ## [1.1.6] - 2022-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning].
 
 - Add deprecation warning for end-of-life (EOL) of v1 of this Action.
 - Update dependencies (shescape).
+- Update the step name for this Action in the documentation.
 
 ## [1.1.5] - 2022-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versioning].
 ## [1.1.6] - 2022-03-27
 
 - Add deprecation warning for end-of-life (EOL) of v1 of this Action.
-- Update dependencies (shescape).
+- Update dependencies (_shescape_).
 - Update the step name for this Action in the documentation.
 
 ## [1.1.5] - 2022-02-26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ Note that the end-to-end tests for this project run `npm run build` before
 testing begins. So, code changes will always be tested.
 
 [contributing guidelines on `main`]: https://github.com/ericcornelissen/git-tag-annotation-action/blob/main/CONTRIBUTING.md
+[editorconfig]: https://editorconfig.org/
 [open bug reports]: https://github.com/ericcornelissen/git-tag-annotation-action/labels/bug
 [open an issue with a bug report]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new?labels=bug
 [open an issue with a feature request]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new?labels=enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,12 @@ to contribute anything, please use the following this workflow
 
 ## New Features
 
-The simplicity of this Action is by design. It is unlikely new features will be
-added to the Action, but you are free to [open an issue with a feature request].
-Please avoid implementing a new feature before submitting an issue for it first!
+Version 1 of the Git Tag Annotation Action will not receive any new features.
 
 ## Bugs
 
-We take bugs seriously. Please report a bug as soon as you discover one. To do
-this [open an issue with a bug report]. You are also free to contribute by
-fixing one of the [open bug reports] and opening a Pull Request for it.
+Version 1 of the Git Tag Annotation Action will not receive any bug fixes,
+unless the bug has an impact on the security of the Action.
 
 ## Project Setup
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ function getOutputFormatUnix() {
 
 function main({ childProcess, core, env, platform, shescape }) {
   core.warning(
-    "General support for git-tag-annotation-action@v1 ends 2022-04-30, " +
+    "General support for git-tag-annotation-action@v1 has ended, " +
       "Security support ends 2022-07-29. " +
       "Please upgrade to git-tag-annotation-action@v2 as soon as possible."
   );

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -149,7 +149,7 @@ for (const platform of [linux, win32]) {
     assert.ok(
       context.core.warning.calledWithExactly(
         sinon.match(
-          "General support for git-tag-annotation-action@v1 ends 2022-04-30"
+          "General support for git-tag-annotation-action@v1 has ended"
         )
       )
     );


### PR DESCRIPTION
Following [the annotation warning](https://github.com/ericcornelissen/git-tag-annotation-action/blob/2ef5e845dd2c6de2e8aeb494610a90f689a05824/src/main.js#L17-L21), this makes changes to the `main-v1` branch to officially end the general support of v1 of this Action.