### PR TITLE
Update release guidelines for v1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,9 +21,6 @@ The release process is as follows:
    accordance with [Semantic Versioning].
 1. Review the created Pull Request and merge if everything looks OK. After
    merging a [git tag] for the new version will be created automatically.
-1. Create a new [GitHub Release] for the (automatically) created tag. If the
-   version should be published to the [GitHub Marketplace] ensure that checkbox
-   is checked.
 
 ## Manual Releases (Discouraged)
 


### PR DESCRIPTION
Omit the step for "Create a new GitHub Release" for v1 releases. I think no GitHub Release should be created for v1 releases as it messes up the [latest release link](https://github.com/ericcornelissen/git-tag-annotation-action/releases/latest) - i.e. if a v1 release is created after a v2 release, then the latest release link will point to the v1 release, which is not actually the latest release (of interest).