### PR TITLE
Add scheduled workflow to audit dependencies

### DIFF
--- a/.github/workflows/deps-analysis.yml
+++ b/.github/workflows/deps-analysis.yml
@@ -13,7 +13,13 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@v1.4.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            artifactcache.actions.githubusercontent.com:443
+            ghcr.io:443
+            github.com:443
+            n06iacprodeus1file4.blob.core.windows.net:443
+            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
         with:
@@ -34,7 +40,13 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@v1.4.3
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            artifactcache.actions.githubusercontent.com:443
+            ghcr.io:443
+            github.com:443
+            n06iacprodeus1file4.blob.core.windows.net:443
+            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/deps-analysis.yml
+++ b/.github/workflows/deps-analysis.yml
@@ -1,5 +1,6 @@
 name: Dependency Analysis
 on:
+  push:
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/deps-analysis.yml
+++ b/.github/workflows/deps-analysis.yml
@@ -1,6 +1,5 @@
 name: Dependency Analysis
 on:
-  push:
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/deps-analysis.yml
+++ b/.github/workflows/deps-analysis.yml
@@ -1,0 +1,50 @@
+name: Dependency Analysis
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions: read-all
+
+jobs:
+  npm-main:
+    name: Audit npm on main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v1.4.3
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.2
+        with:
+          ref: main
+      - name: Install Node.js
+        uses: actions/setup-node@v3.2.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Initialize repository
+        run: npm ci
+      - name: Audit npm dependencies
+        run: npm audit
+  audit-main-v1:
+    name: Audit npm on main-v1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v1.4.3
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.2
+        with:
+          ref: main-v1
+      - name: Install Node.js
+        uses: actions/setup-node@v3.2.0
+        with:
+          cache: npm
+          node-version-file: .nvmrc
+      - name: Initialize repository
+        run: npm ci
+      - name: Audit npm dependencies
+        run: npm audit


### PR DESCRIPTION
Add a new GitHub Actions workflow for auditing dependencies. It is scheduled weekly for an initial trail, and audits dependencies on both `main` and `main-v1`. The latter is especially of interest, as it a failed job would alert about problems on v1 that are not present on v2 (since `npm audit` exits with a non-zero exit code if a problem is detected). The former is more-or-less already covered by Dependabot, nevertheless, it's there for completeness.