### PR TITLE
Add support for GitHub Actions Kotlin DSL

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -213,12 +213,7 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
             github.com:443
-            n06iacprodeus1file4.blob.core.windows.net:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
       - name: Validate Action Types

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,6 +8,7 @@ on:
       - "test/**.js"
       - ".nvmrc"
       - "action.yml"
+      - "action-types.yml"
       - "index.js"
       - "package-lock.json"
       - "rollup.config.js"
@@ -21,6 +22,7 @@ on:
       - ".nvmrc"
       - "index.js"
       - "action.yml"
+      - "action-types.yml"
       - "package-lock.json"
       - "rollup.config.js"
       - "stryker.config.json"
@@ -202,3 +204,15 @@ jobs:
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_TOKEN }}
         run: npm run test:mutation
+  validate-action-types:
+    name: Validate Action Types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v1.4.4
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.2
+      - name: Validate Action Types
+        uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -211,7 +211,14 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@v1.4.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            artifactcache.actions.githubusercontent.com:443
+            github.com:443
+            n06iacprodeus1file4.blob.core.windows.net:443
+            objects.githubusercontent.com:443
+            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
       - name: Validate Action Types

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -222,4 +222,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
       - name: Validate Action Types
-        uses: krzema12/github-actions-typing@v0
+        uses: krzema12/github-actions-typing@v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add support for GitHub Actions Kotlin DSL. ([#262])
 
 ## [2.0.1] - 2022-07-17
 
@@ -115,3 +115,4 @@ Versioning].
 [#240]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/240
 [#241]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/241
 [#254]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/254
+[#262]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/262

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,10 @@
+# This file provides types for "GitHub Actions Kotlin DSL".
+# See https://github.com/krzema12/github-actions-kotlin-dsl
+
+inputs:
+  tag:
+    type: string
+
+outputs:
+  git-tag-annotation:
+    type: string

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,12 @@ inputs:
   tag:
     description: "tag of interest (defaults to the GITHUB_REF environment variable)"
     required: false
+    type: string
 
 outputs:
   git-tag-annotation:
     description: "The git tag annotation"
+    type: string
 
 runs:
   using: "node16"

--- a/action.yml
+++ b/action.yml
@@ -6,12 +6,10 @@ inputs:
   tag:
     description: "tag of interest (defaults to the GITHUB_REF environment variable)"
     required: false
-    type: string
 
 outputs:
   git-tag-annotation:
     description: "The git tag annotation"
-    type: string
 
 runs:
   using: "node16"


### PR DESCRIPTION
Add support for usage of this Action with [GitHub Actions Kotlin DSL](https://github.com/krzema12/github-actions-kotlin-dsl) by adding a `action-types.yml` file with type definitions for Action inputs and outputs.

Also, use the [GitHub Actions Typing Action](https://github.com/krzema12/github-actions-typing) to validate the validity of this `action-types.yml` file.