### PR TITLE
Add a configuration file for Fossa

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,9 @@
+# Check out Fossa at: https://fossa.com/
+
+version: 3
+
+server: https://app.fossa.com
+
+paths:
+  exclude:
+    - ./lib


### PR DESCRIPTION
Primarily to exclude the bundled files in the `lib/` folder from being included in the analysis.