### PR TITLE
Revert "Add a configuration file for Fossa"

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,9 +1,0 @@
-# Check out Fossa at: https://fossa.com/
-
-version: 3
-
-server: https://app.fossa.com
-
-paths:
-  exclude:
-    - ./lib


### PR DESCRIPTION
Reverts ericcornelissen/git-tag-annotation-action#318

It does not appear that the Fossa-GitHub integration respects the configuration file.