### PR TITLE
Use `pull_request_target` in verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,6 @@
 name: Verify code
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - ".github/workflows/verify.yml"
       - ".github/codecov.yml"


### PR DESCRIPTION
...because Pull Requests from e.g. Dependabot do not seem to have access to secrets leading to jobs like `licenses` and `test-mutation` to (partially) fail.