### PR TITLE
Revert 2 pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- Update dependency _actions/core_. ([#326])
+- _No changes yet_
 
 ## [2.0.3] - 2022-09-11
 
@@ -129,4 +129,3 @@ Versioning].
 [#262]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/262
 [#271]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/271
 [#282]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/282
-[#326]: https://github.com/ericcornelissen/git-tag-annotation-action/pull/326

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "1.10.0",
+        "@actions/core": "1.9.1",
         "shescape": "1.5.10"
       },
       "devDependencies": {
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "actions"
   ],
   "dependencies": {
-    "@actions/core": "1.10.0",
+    "@actions/core": "1.9.1",
     "shescape": "1.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts ericcornelissen/git-tag-annotation-action#326 given the failing build on 93ea7a5c024abd787bc787018799cf882a42cb5b
Reverts ericcornelissen/git-tag-annotation-action#330 given that failing build wasn't detected in ericcornelissen/git-tag-annotation-action#326 as a result of running the tests on the `main` branch instead of the PR branch (because apparently that's how `pull_request_target` works :sweat_smile:)