### PR TITLE
Create "audit" commands

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -69,7 +69,7 @@ jobs:
         run: npm ci
       - name: Audit all npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
-        run: npm audit
+        run: npm audit # TODO: Replace with `run: npm run audit`
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
-        run: npm audit --omit dev
+        run: npm audit --omit dev # TODO: Replace with `run: npm run audit:prod`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,10 +147,16 @@ The project is vetted using a small collection of static analysis tools. Run
 
 ##### Vulnerabilities
 
-To scan for vulnerabilities in Node.js dependencies, run:
+To scan for vulnerabilities in all npm dependencies, run:
 
 ```shell
-npm audit
+npm run audit
+```
+
+To scan for vulnerabilities in runtime npm dependencies only, run:
+
+```shell
+npm run audit:prod
 ```
 
 ##### Licenses

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   "scripts": {
     "prepare": "is-ci || husky install script/hooks",
     "_prettier": "prettier ./**/*.{js,json,md,yml} !lib/* --ignore-path .gitignore",
+    "audit": "npm audit",
+    "audit:prod": "npm audit --omit dev",
     "build": "rollup --config rollup.config.js",
     "check-licenses": "fossa analyze && fossa test",
     "clean": "git clean --force -X .temp/ _reports/ && git checkout HEAD ./lib",


### PR DESCRIPTION
### Summary

Create two new npm scripts/commands for auditing dependencies and auditing only production dependencies. These (still) work using `npm audit`.

The reasoning behind adding these is that it gives a permanent command that can have a changing underlying implementation over time. Making contributors remember less as well as allowing for things such as having different auditing mechanisms for different refs use the same CI workflow (e.g. v2, v3, and `main`).