### PR TITLE
Update license check in CI to use the Fossa Action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,13 +79,15 @@ jobs:
             raw.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - name: Install Fossa CLI
-        run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+      - name: Scan licenses
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
       - name: Check licenses
-        env:
-          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-        run: npm run check-licenses
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #324

---

### Summary

Replace downloading the Fossa CLI in the CI by using the [Fossa Action](https://github.com/fossas/fossa-action). Hopefully this will address some timeout issues we've experienced in the CI due to the `fossa test` call taking too long (**EDIT**: welp, [it doesnt...](https://github.com/ericcornelissen/git-tag-annotation-action/actions/runs/3277163463/jobs/5394086883)). Unfortunately this still relies on the Fossa API secret, with all associated drawbacks.