### PR TITLE
Update deprecated set-output feature in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         id: version
         run: |
           VERSION="v$(jq -r '.version' < package.json)"
-          echo "name=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
             echo "released=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,11 @@ jobs:
         id: version
         run: |
           VERSION="v$(jq -r '.version' < package.json)"
-          echo "::set-output name=version::$VERSION"
+          echo "name=$VERSION" >> $GITHUB_OUTPUT
           if [ "$(git tag --list "$VERSION")" ]; then
-            echo "::set-output name=released::true"
+            echo "released=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=released::false"
+            echo "released=false" >> $GITHUB_OUTPUT
           fi
       - name: Release new version
         if: ${{ steps.version.outputs.released == 'false' }}


### PR DESCRIPTION
- Updated deprecated `set-output` feature in `release` workflow.
- Closes #359 
