### PR TITLE
Create c8 configuration file

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,15 @@
+{
+  "all": true,
+  "check-coverage": true,
+
+  "include": ["src/"],
+  "exclude": [],
+
+  "branches": 100,
+  "functions": 100,
+  "lines": 100,
+  "statements": 100,
+
+  "reports-dir": "_reports/coverage",
+  "reporter": ["lcov", "text"]
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "audit:prod": "better-npm-audit audit --production",
     "build": "rollup --config rollup.config.js",
     "clean": "git clean --force -X .cache/ .temp/ _reports/ && git checkout HEAD ./lib",
-    "coverage": "c8 --reports-dir=_reports/coverage --reporter=lcov --reporter=text npm test",
+    "coverage": "c8 --config .c8rc.json npm test",
     "format": "npm run _prettier -- --write",
     "license-check": "licensee --errors-only",
     "lint": "npm run _prettier -- --check",


### PR DESCRIPTION
Move the c8 configuration from `package.json` (CLI args) into a dedicated c8 configuration file, reference the configuration file explicitly to aid with understanding for anyone unfamiliar with c8.

On top of what was already configured, configure what should files should be considered for coverage an minimum coverage thresholds.