### PR TITLE
Pin all runner images in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -187,7 +187,6 @@ jobs:
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         [{"ref":"${{ github.ref }}"}]
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -44,7 +44,7 @@ jobs:
         run: npm run build
   codeql:
     name: CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       security-events: write
     steps:
@@ -70,7 +70,7 @@ jobs:
         uses: github/codeql-action/analyze@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
   licenses:
     name: Licenses
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -97,7 +97,7 @@ jobs:
         run: npm run license-check
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -136,7 +136,7 @@ jobs:
         run: npm run lint:sh
   test-unit:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:
@@ -181,13 +181,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
+          - macos-11
+          - ubuntu-20.04
+          - windows-2022
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         with:
           disable-sudo: true
           egress-policy: block
@@ -230,7 +230,7 @@ jobs:
           fi
   test-mutation:
     name: Mutation tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test-unit
     steps:
@@ -283,7 +283,7 @@ jobs:
         run: npm run test:mutation -- --incremental --force
   validate-action-types:
     name: Action types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
@@ -298,7 +298,7 @@ jobs:
         uses: krzema12/github-actions-typing@c62d4007d3d5d487152f92af8b595bb6b4a10d6f # v0.6.0
   vet:
     name: Vet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           file: ./_reports/coverage/lcov.info
   test-e2e:
-    name: End-to-end tests
+    name: End-to-end tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     needs:
       - build
@@ -180,10 +180,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-11
-          - ubuntu-20.04
-          - windows-2022
+        include:
+          - name: MacOS
+            os: macos-11
+          - name: Ubuntu
+            os: ubuntu-20.04
+          - name: Windows
+            os: windows-2022
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       released: ${{ steps.version.outputs.released }}
       release_notes: ${{ steps.version.outputs.release_notes }}
@@ -47,7 +47,7 @@ jobs:
           fi
   github:
     name: GitHub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ needs.check.outputs.released == 'false' }}
     needs:
       - check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   initiate:
     name: Initiate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   npm:
     name: npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
         run: npm run audit:prod -- ${{ matrix.args }}
   secrets:
     name: Secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0


### PR DESCRIPTION
Update all GitHub Actions workflows to use a specific runner image for all jobs. The chosen images are based on what the documented `latest` images are on December 9, 2022. Upgrading to more recent images may be done separately.

Doing this should help with reproducability. It's currently not known if Dependabot will keep these up-to-date automatically, but since upgrades for these are generally uncommon manually keeping them up-to-date should be doable.