### PR TITLE
Add `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,14 +123,10 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
-      - name: Install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: 1.17
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Initialize repository
-        run: |
-          npm ci
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
+        run: npm ci
       - name: Lint formatting
         run: npm run lint
       - name: Lint Dockerfile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+act 0.2.34
 actionlint 1.6.22
 shellcheck 0.8.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+actionlint 1.6.22
+shellcheck 0.8.0


### PR DESCRIPTION
Relates to #421

---

### Summary

Create a `.tool-versions` file with currently untracked dependencies (that we want to track). This file is first a configuration format for [asdf], but is also human-readable and thus can be used to know and track what versions of dependencies _should_ be used.

[asdf]: https://asdf-vm.com/