### PR TITLE
Pin hadolint to a version (instead of hash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "license-check": "licensee --errors-only",
     "lint": "npm run _prettier -- --check",
     "lint:ci": "actionlint",
-    "lint:docker": "docker run -i --rm --mount \"type=bind,source=$(pwd)/.hadolint.yml,target=/.config/hadolint.yaml\" hadolint/hadolint@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b < ./.devcontainer/Dockerfile",
+    "lint:docker": "docker run -i --rm --mount \"type=bind,source=$(pwd)/.hadolint.yml,target=/.config/hadolint.yaml\" hadolint/hadolint:v2.12.0 < ./.devcontainer/Dockerfile",
     "lint:md": "markdownlint --dot --ignore-path .gitignore .",
     "lint:sh": "shellcheck -e SC1090,SC1091,SC2155 script/hooks/*.sh script/hooks/pre-*",
     "test": "uvu test",


### PR DESCRIPTION
Relates to #384, #421

## Summary

Change the `lint:docker` command details to run from a version tag instead of an image hash. Image hashes are tied to the target architecture, making it inconvenient for this particular use case. Switching to a version tag still provides good reproducibility guarantees (it can be expected that a version isn't re-published) - in contrast to an image hash which provides better reproducibility guarantees (it makes re-publishing cryptographically difficult) and by extension more secure.