### PR TITLE
Bump ShellCheck to latest

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 act 0.2.34
 actionlint 1.6.22
-shellcheck 0.8.0
+shellcheck 0.9.0


### PR DESCRIPTION
Relates to #421, #435

## Summary

Bump ShellCheck from `0.8.0` to `0.9.0`.