### PR TITLE
Update pre-commit

### DIFF
--- a/script/hooks/pre-commit
+++ b/script/hooks/pre-commit
@@ -3,7 +3,7 @@
 . "$(dirname "$0")/common.sh"
 
 # Pre
-LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc --lines)
+LIB_STAGED_COUNT=$(git diff --name-only --staged lib/ | wc -l)
 if [ "$LIB_STAGED_COUNT" -ne "0" ]; then
   echo "[INFO] All changes to the lib/ directory have been unstaged"
   echo "[INFO] Changes in the lib/ directory should not be committed"


### PR DESCRIPTION
## Summary

Update the use of `wc` in to use the shorthand "-l" over "--lines" because the latter isn't supported by all variants of the `wc` tool.