### PR TITLE
Bump json5 from 2.2.1 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4633,9 +4633,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"


### PR DESCRIPTION
Bump `json5` from v2.2.1 to v2.2.2 following [today's nightly run](https://github.com/ericcornelissen/git-tag-annotation-action/actions/runs/3798051330/jobs/6459476874) because of GHSA-9c47-m6qq-7p4h / CVE-2022-46175.

As a transitive dependency of `@stryker-mutator/core`, `depcheck`, and `unimported` this dependency does not have an impact on this action at Runtime, so no release (or changelog entry) is necessary.