### PR TITLE
Configure harden-runner for "Publish / GitHub"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,15 @@ jobs:
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            rekor.sigstore.dev:443
+            sigstore-tuf-root.storage.googleapis.com:443
+            storage.googleapis.com:443
+            uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:


### PR DESCRIPTION
Relates to #436, #459

## Summary

Was set to audit after adding release signing. Re-setting to block after having run the job to release v2.0.6. See also https://app.stepsecurity.io/github/ericcornelissen/git-tag-annotation-action/actions/runs/3828526299