### PR TITLE
Add `cosign` to .tool-versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            gitlab.com:443
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
         tool:
           - act
           - actionlint
+          - cosign
           - shellcheck
     steps:
       - name: Harden runner

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            gitlab.com:443
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,10 +77,15 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           fetch-depth: 0 # To fetch all major version branches
+      - name: Get cosign version
+        id: versions
+        run: |
+          COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
+          echo "cosign=$COSIGN_VERSION" >> "$GITHUB_OUTPUT"
       - name: Install cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
         with:
-          cosign-release: v1.13.1
+          cosign-release: v${{ steps.versions.outputs.cosign }}
       - name: Get major version
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
         id: major-version

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,5 @@
 
 act 0.2.35
 actionlint 1.6.22
+cosign 1.13.1
 shellcheck 0.9.0


### PR DESCRIPTION
Relates to #421, #448

## Summary

Keep the version of `cosign` used by this project tracked by storing it in the `.tool-versions` file.