### PR TITLE
Separate git and GitHub (Release) job for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,14 +50,49 @@ jobs:
               echo 'EOF'
             } >> "$GITHUB_OUTPUT"
           fi
+  git:
+    name: git
+    runs-on: ubuntu-22.04
+    if: ${{ needs.check.outputs.released == 'false' }}
+    needs:
+      - check
+    permissions:
+      contents: write # To push a tag and a branch
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0 # To fetch all major version branches
+      - name: Get major version
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        id: major-version
+        with:
+          result-encoding: string
+          script: |
+            const version = "${{ needs.check.outputs.version }}"
+            const major = version.replace(/\.\d\.\d$/, "")
+            return major
+      - name: Release new version
+        run: |
+          git tag '${{ needs.check.outputs.version }}'
+          git push origin '${{ needs.check.outputs.version }}'
+      - name: Update major version branch
+        run: |
+          git push origin 'HEAD:${{ steps.major-version.outputs.result }}'
   github:
     name: GitHub
     runs-on: ubuntu-22.04
     if: ${{ needs.check.outputs.released == 'false' }}
     needs:
       - check
+      - git
     permissions:
-      contents: write # To push a tag, a branch, and create a GitHub Release
+      contents: write # To create a GitHub Release
       id-token: write # To perform keyless signing with cosign
     steps:
       - name: Harden runner
@@ -75,28 +110,10 @@ jobs:
             uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          fetch-depth: 0 # To fetch all major version branches
       - name: Install cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
         with:
           cosign-release: v1.13.1
-      - name: Get major version
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
-        id: major-version
-        with:
-          result-encoding: string
-          script: |
-            const version = "${{ needs.check.outputs.version }}"
-            const major = version.replace(/\.\d\.\d$/, "")
-            return major
-      - name: Release new version
-        run: |
-          git tag '${{ needs.check.outputs.version }}'
-          git push origin '${{ needs.check.outputs.version }}'
-      - name: Update major version branch
-        run: |
-          git push origin 'HEAD:${{ steps.major-version.outputs.result }}'
       - name: Sign Action
         env:
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
## Summary

Separate concerns. Also reduce scope of `id-token` permission