### PR TITLE
Adjust retry timings for getting latest version of tools

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,8 +46,8 @@ jobs:
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
           max_attempts: 3
-          retry_wait_seconds: 30
-          timeout_minutes: 1
+          retry_wait_seconds: 120
+          timeout_seconds: 20
           command: >-
             LATEST_VERSION="$(asdf latest '${{ matrix.tool }}')"
             &&


### PR DESCRIPTION
Relates to  #470

## Summary

Increase retry wait time. 30 seconds proved to not be sufficient for getting success on the second try, trying 2 minutes now. Also reduce the timeout to 20 seconds, in general, if successful, this steps takes only a couple of seconds.

See also https://github.com/ericcornelissen/git-tag-annotation-action/actions/runs/3908028622/attempts/1