### PR TITLE
Add yamllint to `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,10 +27,11 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install asdf
         uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Install tooling
+      - name: Add plugins
         run: |
          asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
-         asdf install
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Lint CI workflows
         if: ${{ failure() || success() }}
         run: make lint-ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443
+            pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install asdf

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,8 +25,12 @@ jobs:
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
+         asdf install
       - name: Lint CI workflows
         if: ${{ failure() || success() }}
         run: make lint-ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            files.pythonhosted.org:443
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,7 @@ jobs:
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443
+            pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install asdf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,10 +37,11 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install asdf
         uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Install tooling
+      - name: Add plugins
         run: |
          asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
-         asdf install
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
         id: release-token

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,7 @@ jobs:
           - actionlint
           - cosign
           - shellcheck
+          - yamllint
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v2.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,8 +35,12 @@ jobs:
             objects.githubusercontent.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
+         asdf install
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
         id: release-token

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            files.pythonhosted.org:443
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ act 0.2.35
 actionlint 1.6.22
 cosign 1.13.1
 shellcheck 0.9.0
+yamllint 1.28.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ To be able to contribute you need the following tooling:
 - (Recommended) a code editor with [EditorConfig] support;
 - (Suggested) [actionlint] (see `.tool-versions` for preferred version);
 - (Suggested) [ShellCheck] (see `.tool-versions` for preferred version);
-- (Suggested) [yamllint] v1.26.3;
+- (Suggested) [yamllint] (see `.tool-versions` for preferred version);
 - (Optional) [act] v0.2.22 or higher;
 - (Optional) [Docker];
 - (Optional) [Node.js] v18 or higher;


### PR DESCRIPTION
Relates to #421, #462

## Summary

Add [yamllint](https://github.com/adrienverge/yamllint) to `.tool-versions` and use [ericcornelissen/asdf-yamllint](https://github.com/ericcornelissen/asdf-yamllint). Set it to `1.28.0` because that's the version I had installed locally.