### PR TITLE
Create convenience Make targets for change verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ as clearly as possible.
 To be able to contribute you need the following tooling:
 
 - [git];
+- [Make];
 - (Recommended) a code editor with [EditorConfig] support;
 - (Suggested) [actionlint] (see `.tool-versions` for preferred version);
 - (Suggested) [ShellCheck] (see `.tool-versions` for preferred version);
@@ -113,8 +114,13 @@ If you decide to contribute anything, please use the following workflow:
 
 #### Formatting and Linting
 
-This project uses linters to catch mistakes. Use the following command to check
-your changes if applicable:
+This project uses linters to catch mistakes and enforce style. Run:
+
+```shell
+make lint
+```
+
+to run all linters or use the following commands to check specific file types:
 
 | File type        | Command            | Linter         |
 | :--------------- | :----------------- | :------------- |
@@ -161,6 +167,7 @@ There are some limitations to using [act]:
 [editorconfig]: https://editorconfig.org/
 [feature request]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new?labels=enhancement
 [git]: https://git-scm.com/
+[make]: https://www.gnu.org/software/make/
 [node.js]: https://nodejs.org/en/
 [open an issue]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new
 [open issues]: https://github.com/ericcornelissen/git-tag-annotation-action/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ help: ## Show this help message
 		printf "  \033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
+lint: lint-ci lint-sh lint-yaml ## Lint the project
+
 lint-ci: ## Lint Continuous Integration configuration files
 	@actionlint
 
@@ -39,4 +41,6 @@ test-run: ## Run the action locally
 		./src/main.sh \
 	)
 
-.PHONY: clean default help lint-ci lint-sh lint-yaml test test-run
+verify: lint test-run ## Verify project is in a good state
+
+.PHONY: clean default help lint lint-ci lint-sh lint-yaml test test-run verify


### PR DESCRIPTION
## Summary

Add two new [Make](https://www.gnu.org/software/make/) targets for contributor convenience:

1. `lint`: to run all lint targets
2. `verify`: to run most verification targets (e.g. lint and test) to quickly validate changes are correct.