### PR TITLE
Update `nightly.yml`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           token: ${{ steps.release-token.outputs.token }}
           title: Update ${{ matrix.tool }} to v${{ env.latest }}
-          body:
+          body: |
             _This Pull Request was created automatically_
 
             ---


### PR DESCRIPTION
## Summary

Correct body template for tool version updates.

As seen in #483, the first line of the template is currently rendered as a title because of the `---` following it. Without the `|` after `body:`, newlines are stripped from the template.