### PR TITLE
Update tooling setup in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,11 +27,6 @@ jobs:
             pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-          asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Lint CI workflows

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,11 +37,6 @@ jobs:
             pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-          asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Create token to create Pull Request


### PR DESCRIPTION
Relates to #462, #479 

## Summary

Simplify the tooling setup with [asdf](https://asdf-vm.com/) in CI. Remove the now-unnecessary explicit setup of the [yamllint plugin](https://github.com/ericcornelissen/asdf-yamllint).