### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Eric Cornelissen
+Copyright (c) 2023 Eric Cornelissen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Update the copyright year for the source code. Triggered, in part, by [`curl`s recent related decision](https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/). I re-reviewed the usage of license texts in this project and this is the only place with a year.