### PR TITLE
Update CI egress policy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,10 +21,12 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -44,10 +46,12 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install tooling
@@ -47,6 +48,7 @@ jobs:
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install tooling

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,7 @@ jobs:
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Install tooling

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,10 +32,12 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
             github.com:443
             gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION
Relates to #148

## Summary

Allow call to `sigstore-tuf-root.storage.googleapis.com:443` in workflows. It's already allowed in `publish.yml`, now also in other workflows as it's being called out to when cosign is being installed.