### PR TITLE
Generate and upload Semgrep SARIF report

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,15 +96,23 @@ jobs:
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    permissions:
+      security-events: write # To upload SARIF results
     container:
       image: returntocorp/semgrep
     steps:
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform Semgrep analysis
-        run: semgrep ci
+        run: semgrep ci --sarif --output semgrep.sarif
+      - name: Upload Semgrep report to GitHub
+        uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b # v2.2.9
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: semgrep.sarif
   test-e2e:
     name: End-to-end tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Relates to #502

## Summary

Update the "Check / Semgrep" job to have Semgrep generate an output in [SARIF](https://sarifweb.azurewebsites.net/) format and upload that to GitHub using [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action). See also the [relevant GitHub documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github) as well as the [Semgrep CLI documentation](https://semgrep.dev/docs/cli-reference/).

Also don't run Semgrep for PRs by Dependabot as it doesn't have access to `secrets.SEMGREP_APP_TOKEN`. In turn the `semgrep` invocation doesn't do anything, as a result of which uploading the SARIF file will fail (leading to an job failure).