### PR TITLE
Reduce availability scope of the `SEMGREP_APP_TOKEN` secret

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,8 +97,6 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-22.04
     if: ${{ github.actor != 'dependabot[bot]' }}
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     permissions:
       security-events: write # To upload SARIF results
     container:
@@ -108,6 +106,8 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Perform Semgrep analysis
         run: semgrep ci --sarif --output semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep report to GitHub
         uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b # v2.2.9
         if: ${{ failure() || success() }}


### PR DESCRIPTION
Relates to #502, #513

## Summary

Only make the `SEMGREP_APP_TOKEN` available in the job step that needs it, as opposed to the whole job. Following the principle of least privilege.