### PR TITLE
Add explicit license for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,17 @@ For more information regarding this problem see [actions/checkout#290].
 Please [open an issue] if you found a mistake or if you have a suggestion for
 how to improve the documentation.
 
+---
+
+_Content licensed under [CC BY-SA 4.0]; Code snippets under the [MIT license]._
+
 [actions/checkout@v1]: https://github.com/actions/checkout/tree/v1
 [actions/checkout@v2]: https://github.com/actions/checkout/tree/v2
 [actions/checkout@v3]: https://github.com/actions/checkout/tree/v3
 [actions/checkout#290]: https://github.com/actions/checkout/issues/290
+[cc by-sa 4.0]: https://creativecommons.org/licenses/by-sa/4.0/
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
+[mit license]: https://opensource.org/license/mit/
 [open an issue]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new
 [permissions]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 [ci-url]: https://github.com/ericcornelissen/git-tag-annotation-action/actions/workflows/check.yml


### PR DESCRIPTION
## Summary

Make documentation text available under CC BY-SA 4.0 and snippets under the MIT license (like the main code).