### PR TITLE
Update egress policies for CI jobs installing tooling with asdf

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,7 @@ jobs:
             pypi.org:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install tooling
@@ -53,6 +54,7 @@ jobs:
             pypi.org:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install tooling

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
             pypi.org:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install tooling

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,7 @@ jobs:
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1


### PR DESCRIPTION
Relates to #535

## Summary

Since using cosign 2.0.2 jobs installing tooling use a new endpoint during installation.