### PR TITLE
Rename secrets for automation purposes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,13 +32,13 @@ jobs:
             tuf-repo-cdn.sigstore.dev:443
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        id: release-token
+        id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@4aa009179b76d163c08a950036ac508bd5520d0c # v0.3.1
         with:
           labels: dependencies
           max: 1
-          token: ${{ steps.release-token.outputs.token }}
+          token: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
           node-version-file: .nvmrc
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        id: release-token
+        id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Bump version
         env:
           UPDATE_TYPE: ${{ github.event.inputs.update_type }}
@@ -53,7 +53,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
-          token: ${{ steps.release-token.outputs.token }}
+          token: ${{ steps.automation-token.outputs.token }}
           title: New ${{ github.event.inputs.update_type }} release for v2
           body: |
             _This Pull Request was created automatically_


### PR DESCRIPTION
Relates to #397, #460

## Summary

Rename `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` to `AUTOMATION_APP_ID` and `AUTOMATION_APP_PRIVATE_KEY` as these aren't used for release purposes exclusively.