### PR TITLE
Make tests POSIX compliant

### DIFF
--- a/test/security.bats
+++ b/test/security.bats
@@ -4,7 +4,7 @@ setup() {
   load 'test_helper/bats-support/load'
   load 'test_helper/bats-assert/load'
 
-  rm --force github_output
+  rm -f github_output
 }
 
 @test "argument splitting, context tag" {

--- a/test/test.bats
+++ b/test/test.bats
@@ -4,7 +4,7 @@ setup() {
   load 'test_helper/bats-support/load'
   load 'test_helper/bats-assert/load'
 
-  rm --force github_output
+  rm -f github_output
 }
 
 @test "only context tag" {


### PR DESCRIPTION
Relates to #577

## Summary

Update the tests to be POSIX compliant so that they run (out of the box) on more systems.