### PR TITLE
Configure Dependabot to update git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     labels:
       - ci/cd
       - dependencies
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies


### PR DESCRIPTION
Relates to #40, #95, #577

## Summary

Update the Dependabot configuration to keep the git submodules up-to-date. I believe the directory should be `/` because `.gitmodules` is at the project root. Set to a monthly cadence because I currently believe keeping these up-to-date on a more regular basis isn't necessary.

Values are based on [the Dependabot documentation (accessed August 7, 2023)](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).