### PR TITLE
Format shell scripts in CI workflows the same as `.sh` files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -157,7 +157,7 @@ jobs:
           - Run the Action to get the git tag annotation of a specified tag.
           '
 
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
             exit 1
           fi
   validate-action-types:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,17 +39,17 @@ jobs:
         id: version
         run: |
           VERSION="v$(cat .version)"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$(git tag --list "$VERSION")" ]; then
-            echo 'released=true' >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
+          if [ "$(git tag --list "${VERSION}")" ]; then
+            echo 'released=true' >>"${GITHUB_OUTPUT}"
           else
-            echo 'released=false' >> "$GITHUB_OUTPUT"
+            echo 'released=false' >>"${GITHUB_OUTPUT}"
 
             {
               echo 'release_notes<<EOF'
               node script/get-release-notes.mjs
               echo 'EOF'
-            } >> "$GITHUB_OUTPUT"
+            } >>"${GITHUB_OUTPUT}"
           fi
       - name: Get major version
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
@@ -116,7 +116,7 @@ jobs:
         id: versions
         run: |
           COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
-          echo "cosign=$COSIGN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "cosign=${COSIGN_VERSION}" >>"${GITHUB_OUTPUT}"
       - name: Install cosign
         uses: sigstore/cosign-installer@d13028333d784fcc802b67ec924bcebe75aa0a5f # v3.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Bump version
         env:
           UPDATE_TYPE: ${{ github.event.inputs.update_type }}
-        run: npm version "$UPDATE_TYPE" --no-git-tag-version
+        run: npm version "${UPDATE_TYPE}" --no-git-tag-version
       - name: Update CHANGELOG
         run: node script/bump-changelog.mjs
       - name: Create Pull Request


### PR DESCRIPTION
Relates to #559

## Summary

Update CI workflows containing embedded shell scripts to be formatted the same as `.sh` files.