### PR TITLE
Assert success and `stdout`

### DIFF
--- a/test/security.bats
+++ b/test/security.bats
@@ -18,6 +18,8 @@ setup() {
   expected="annotation<<EOF
 EOF"
 
+  assert_success
+  assert_output ''
   assert_equal "${actual}" "${expected}"
 }
 
@@ -32,6 +34,8 @@ EOF"
   expected="annotation<<EOF
 EOF"
 
+  assert_success
+  assert_output ''
   assert_equal "${actual}" "${expected}"
 }
 
@@ -41,7 +45,10 @@ EOF"
   GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
     GITHUB_REF="refs/tags/${CONTEXT_TAG}" \
     run ./src/main.sh
+
   assert_success
+  assert_success
+  assert_output ''
 }
 
 @test "shell injection, provided tag" {
@@ -50,5 +57,7 @@ EOF"
   GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
     PROVIDED_TAG="${PROVIDED_TAG}" \
     run ./src/main.sh
+
   assert_success
+  assert_output ''
 }

--- a/test/test.bats
+++ b/test/test.bats
@@ -21,6 +21,8 @@ setup() {
 
 EOF"
 
+  assert_success
+  assert_output ''
   assert_equal "${actual}" "${expected}"
 }
 
@@ -38,6 +40,8 @@ EOF"
 
 EOF"
 
+  assert_success
+  assert_output ''
   assert_equal "${actual}" "${expected}"
 }
 
@@ -58,5 +62,7 @@ EOF"
 
 EOF"
 
+  assert_success
+  assert_output ''
   assert_equal "${actual}" "${expected}"
 }


### PR DESCRIPTION
Relates to #577

## Summary

Add assertions for success and `stdout` to all tests. (As far as I can tell bats-core doesn't allow you to make assertions about stderr.)