### PR TITLE
Refactor scripts for consistency

### DIFF
--- a/script/bump-changelog.mjs
+++ b/script/bump-changelog.mjs
@@ -4,14 +4,14 @@ import * as path from "node:path";
 const STR_UNRELEASED = "## [Unreleased]";
 const STR_NO_CHANGES = "- _No changes yet_";
 
-const manifestFile = path.resolve("./.version");
+const versionFile = path.resolve("./.version");
 const changelogFile = path.resolve("./CHANGELOG.md");
 
-const manifestRaw = fs.readFileSync(manifestFile).toString();
-const version = manifestRaw.trim();
+const version = fs.readFileSync(versionFile).toString().trim();
+const versionHeader = `## [${version}]`;
 
 const changelog = fs.readFileSync(changelogFile).toString();
-if (changelog.includes(`## [${version}]`)) {
+if (changelog.includes(versionHeader)) {
   throw new Error(`${version} already in CHANGELOG`);
 }
 

--- a/script/bump-version.mjs
+++ b/script/bump-version.mjs
@@ -2,13 +2,13 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as process from "node:process";
 
-const manifestFile = path.resolve("./.version");
+const versionFile = path.resolve("./.version");
 
-const manifestRaw = fs.readFileSync(manifestFile).toString();
-const version = manifestRaw.trim();
-
+const version = fs.readFileSync(versionFile).toString().trim();
 const newVersion = version.split(".");
-switch (process.argv[2]) {
+
+const arg = process.argv[2];
+switch (arg) {
   case "patch":
     newVersion[2] = parseInt(newVersion[2], 10) + 1;
     break;
@@ -22,9 +22,9 @@ switch (process.argv[2]) {
     newVersion[2] = 0;
     break;
   default:
-    console.log(`unknown argument '${bump}'`);
-    console.log(`must be one of 'patch', 'minor', 'major'`);
-    break;
+    throw new Error(
+      `unknown argument '${arg}', must be one of 'patch', 'minor', 'major'`
+    );
 }
 
-fs.writeFileSync(manifestFile, `${newVersion.join(".")}\n`);
+fs.writeFileSync(versionFile, `${newVersion.join(".")}\n`);

--- a/script/get-release-notes.mjs
+++ b/script/get-release-notes.mjs
@@ -1,12 +1,11 @@
-import fs from "node:fs";
-import path from "node:path";
-import process from "node:process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as process from "node:process";
 
-const manifestFile = path.resolve("./.version");
+const versionFile = path.resolve("./.version");
 const changelogFile = path.resolve("./CHANGELOG.md");
 
-const manifestRaw = fs.readFileSync(manifestFile).toString();
-const version = manifestRaw.trim();
+const version = fs.readFileSync(versionFile).toString().trim();
 const versionHeader = `## [${version}]`;
 
 const changelog = fs.readFileSync(changelogFile).toString();


### PR DESCRIPTION
Relates to #511

## Summary

- Naming and ordering.
- Import formatting using `* as`.
- Erroring using `throw new Error()`.
- Fix unknown variable in bump-version script.