### PR TITLE
Drop dev dependency on `act`

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,5 +1,0 @@
-# Check out act at: https://github.com/nektos/act
-
---platform ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
---quiet
---use-gitignore

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,6 @@
 # - asdf: https://asdf-vm.com/
 # - rtx: https://github.com/jdxcode/rtx
 
-act 0.2.49
 actionlint 1.6.25
 cosign 2.1.1
 shellcheck 0.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,6 @@ To be able to contribute you need the following tooling:
 - (Suggested) [ShellCheck] (see `.tool-versions` for preferred version);
 - (Suggested) [shfmt] (see `.tool-versions` for preferred version);
 - (Suggested) [yamllint] (see `.tool-versions` for preferred version);
-- (Optional) [act] v0.2.22 or higher;
 - (Optional) [Docker];
 - (Optional) [Node.js] v20 or higher;
 
@@ -162,19 +161,6 @@ that are ran in the Continuous Integration as part of the "Check" workflow.
 These tests aim to verify that the Action can run in the GitHub Actions
 environment and outputs the expected values.
 
-You can use [act] to run the end-to-end tests locally. If you have the `act`
-program available on your PATH you can use `make test-e2e` to run the end-to-end
-tests locally.
-
-There are some limitations to using [act]:
-
-- It depends on [Docker] to run workflows.
-- Your system may not support all operating systems the tests should run on.
-  Hence, the end-to-end tests may succeed locally but fail on GitHub because you
-  couldn't run them for all operating systems.
-- All jobs that the end-to-end test job `needs` have to be executed as well.
-
-[act]: https://github.com/nektos/act
 [actionlint]: https://github.com/rhysd/actionlint
 [bash test tools]: https://thorsteinssonh.github.io/bash_test_tools/
 [bug report]: https://github.com/ericcornelissen/git-tag-annotation-action/issues/new?labels=bug

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ test: ## Run the automated tests
 	@./test/test_functional.sh
 	@./test/test_security.sh
 
-test-e2e: ## Run the end-to-end tests
-	@act --job test-e2e
-
 test-run: ## Run the action locally
 	@rm -f ${GITHUB_OUTPUT}
 	@touch ${GITHUB_OUTPUT}


### PR DESCRIPTION
Relates to #226
Supersedes #603

## Summary

The reason is twofold:
1. To reduce dependencies for this relatively inactive project to reduce maintenance burden.
2. There's a test suite that can be run locally.

And, of course, it's still possible to run the e2e tests using `act` - it's just the explicit dependency and basic configuration that are gone.