### PR TITLE
Try `asdf-vm/action` on Node.js v20

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Check formatting
         run: make format-check
   lint:
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Lint CI workflows
         if: ${{ failure() || success() }}
         run: make lint-ci


### PR DESCRIPTION
## Summary

This Pull Request tests an upgrade of `asdf-vm/action` to an unreleased version that runs on Node.js v20.