### PR TITLE
Adopt SPDX license identifiers for file-level license details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to the _Git Tag Annotation Action_ will be documented in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The maintainers of the _Git Tag Annotation Action_ welcome contributions and

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # Git Tag Annotation Action
 
 [![Continuous Integration][ci-image]][ci-url]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 If you need to release a new version of the _Git Tag Annotation Action_, follow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _Git Tag Annotation Action_ project take security issues

--- a/script/bump-changelog.mjs
+++ b/script/bump-changelog.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 

--- a/script/bump-version.mjs
+++ b/script/bump-version.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as process from "node:process";

--- a/script/get-release-notes.mjs
+++ b/script/get-release-notes.mjs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as process from "node:process";

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 {
   echo 'annotation<<EOF'

--- a/test/test_functional.sh
+++ b/test/test_functional.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+
 source ./test/bash_test_tools
 
 GITHUB_OUTPUT='github_output'

--- a/test/test_security.sh
+++ b/test/test_security.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+
 source ./test/bash_test_tools
 
 GITHUB_OUTPUT='github_output'


### PR DESCRIPTION
Relates to #542, #579

## Summary

Add SPDX license identifiers to relevant (non-configuration and not-already-licensed) files to indicate, at the file level, what license applies. This is partially useful for anyone that (somehow) only has access to part of the project, but in the case of some files it actually clarifies the intended license.

