### PR TITLE
Run e2e tests on more runner images

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run tests
         run: make test
   test-e2e:
-    name: End-to-end tests (${{ matrix.name }})
+    name: End-to-end tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs:
       - test-unit
@@ -155,12 +155,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: MacOS
-            os: macos-12
-          - name: Ubuntu
-            os: ubuntu-22.04
-          - name: Windows
-            os: windows-2022
+          - os: macos-11
+          - os: macos-12
+          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+          - os: windows-2019
+          - os: windows-2022
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ jobs:
         run: echo "$ANNOTATION"
 ```
 
+## Runners
+
+This Action is tested on the official [ubuntu-20.04], [ubuntu-22.04],
+[macos-11], [macos-12], [windows-2019], [windows-2022] runner images. It is
+recommended to use one of these images when using this Action.
+
+[macos-11]: https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
+[macos-12]: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+[ubuntu-20.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
+[ubuntu-22.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+[windows-2019]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
+[windows-2022]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+
 ## Security
 
 ### Permissions


### PR DESCRIPTION
Relates to #420

## Summary

Update the e2e test matrix to test against all currently supported runner images. Relatedly, add sections to the various documentation that these runner images are tested and thus recommended.