### PR TITLE
Use explicit registry in `Containerfile` base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 
-FROM alpine:3.18.4
+FROM docker.io/alpine:3.18.4
 
 RUN apk add --no-cache \
 	bash \


### PR DESCRIPTION
Relates to #644

## Summary

Improve compatibility of the `Containerfile` with non-Docker engines.