### PR TITLE
Configure egress policy for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,7 @@ jobs:
             api.github.com:443
             fulcio.sigstore.dev:443
             github.com:443
+            objects.githubusercontent.com:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             storage.googleapis.com:443

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,9 @@ jobs:
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:


### PR DESCRIPTION
Closes #475
Relates to #674
Relates to ["Publish / GitHub" run `8270547728`](https://github.com/ericcornelissen/git-tag-annotation-action/actions/runs/8270547728)